### PR TITLE
Improve layout for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# mkvd
+# Video Player with Segment Selection
+
+This repository contains a Tkinter-based application for playing video files (`.mkv`, `.avi`, `.mp4`).
+The application uses the `python-vlc` package to handle video playback and provides a draggable timeline where multiple segments can be created and edited.
+
+## Requirements
+- Python 3.12+
+- [python-vlc](https://pypi.org/project/python-vlc/) (installed automatically with `pip`)
+- VLC media player installed on the system (required by `python-vlc`)
+
+Install dependencies with:
+
+```bash
+pip install python-vlc
+```
+
+## Usage
+
+Run the application with:
+
+```bash
+python main.py
+```
+
+Use the **Load** button to open a video file. The slider and timeline update as the video plays. Playback controls and the segment list are now grouped in labeled sections for easier navigation.
+You can also move the slider with the left and right arrow keys or the mouse wheel even while playback is paused.
+The size of these jumps is configurable in the **Jump (s)** spinbox next to the controls (default is 1 second).
+Mark a section with **Set Start** and **Set End**, then click **Add Segment** to store it.
+All segments appear in the list below the controls. They can be renamed with **Rename**, edited by entering new start or end values in the fields under the list, and adjusted directly on the timeline by dragging or resizing the colored bars. When the mouse hovers over a segment edge the cursor changes to a left-right arrow so you know it can be resized.
+
+Click **Export** to save each segment as an MP3 file. A folder dialog will ask
+where to place the resulting files. The application expects an `ffmpeg`
+directory next to `main.py` containing the `ffmpeg` executable
+(e.g. `ffmpeg/ffmpeg.exe` on Windows).
+
+The ffmpeg output appears in a dedicated log panel at the bottom of the
+window. The field is fairly tall so longer command output remains readable and
+above it a small status label shows which segment is being exported. While
+export is running all other controls are disabled to prevent changes.
+
+When you pause or stop playback, the current frame remains visible and you can
+scrub the video by dragging or scrolling the slider to preview frames.
+
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,509 @@
+import os
+import subprocess
+import tkinter as tk
+from tkinter import filedialog, messagebox, simpledialog
+from tkinter.scrolledtext import ScrolledText
+import threading
+import queue
+import vlc
+
+class VideoPlayer(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Video Player with Timeline")
+        self.geometry("800x600")
+
+        # VLC player instance
+        self.instance = vlc.Instance()
+        self.player = self.instance.media_player_new()
+
+        # Video panel
+        self.video_panel = tk.Frame(self)
+        self.canvas = tk.Canvas(self.video_panel, bg='black')
+        self.canvas.pack(fill=tk.BOTH, expand=1)
+        self.video_panel.pack(fill=tk.BOTH, expand=1)
+
+        # Timeline slider and canvas grouped for clarity
+        timeline_frame = tk.Frame(self)
+        self.scale = tk.Scale(timeline_frame, from_=0, to=1000,
+                              orient=tk.HORIZONTAL,
+                              command=self.on_slider_move)
+        self.scale.pack(fill=tk.X)
+
+        self.timeline = tk.Canvas(timeline_frame, height=40, bg='grey90')
+        self.timeline.pack(fill=tk.X)
+        self.timeline.bind('<Button-1>', self.on_timeline_click)
+        self.timeline.bind('<B1-Motion>', self.on_timeline_drag)
+        self.timeline.bind('<ButtonRelease-1>', self.on_timeline_release)
+        self.timeline.bind('<Motion>', self.on_timeline_motion)
+        self.timeline.bind('<Leave>', lambda e: self.timeline.config(cursor=''))
+        self.playhead = self.timeline.create_line(0, 0, 0, 40, fill='red')
+        timeline_frame.pack(fill=tk.X, pady=5)
+
+        # Segment management
+        self.segments = []  # list of dicts with id, name, start, end, rect
+        self.active_segment = None
+        self.drag_mode = None
+        self.drag_offset = 0
+        self.video_path = None
+
+        # Playback and editing controls
+        controls = tk.LabelFrame(self, text='Playback')
+        self.control_widgets = []
+        self.load_btn = tk.Button(controls, text="Load", command=self.load_video)
+        self.load_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.load_btn)
+
+        self.play_btn = tk.Button(controls, text="Play", command=self.play)
+        self.play_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.play_btn)
+
+        self.pause_btn = tk.Button(controls, text="Pause", command=self.pause)
+        self.pause_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.pause_btn)
+
+        self.stop_btn = tk.Button(controls, text="Stop", command=self.stop)
+        self.stop_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.stop_btn)
+
+        self.start_btn = tk.Button(controls, text="Set Start", command=self.set_start)
+        self.start_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.start_btn)
+
+        self.end_btn = tk.Button(controls, text="Set End", command=self.set_end)
+        self.end_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.end_btn)
+
+        self.add_btn = tk.Button(controls, text="Add Segment", command=self.add_segment)
+        self.add_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.add_btn)
+
+        self.rename_btn = tk.Button(controls, text="Rename", command=self.rename_segment)
+        self.rename_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.rename_btn)
+
+        self.export_btn = tk.Button(controls, text="Export", command=self.export_segments)
+        self.export_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.export_btn)
+
+        tk.Label(controls, text='Jump (s):').pack(side=tk.LEFT)
+        self.jump_amount = tk.DoubleVar(value=1.0)
+        self.jump_spin = tk.Spinbox(controls, from_=0.1, to=60.0,
+                                   increment=0.1, width=5,
+                                   textvariable=self.jump_amount)
+        self.jump_spin.pack(side=tk.LEFT)
+        self.control_widgets.append(self.jump_spin)
+
+        controls.pack(fill=tk.X, padx=5, pady=5)
+
+        # Segment list and editing
+        seg_frame = tk.LabelFrame(self, text='Segments')
+        self.segment_var = tk.StringVar()
+        self.segment_label = tk.Label(seg_frame, textvariable=self.segment_var)
+        self.segment_label.pack(fill=tk.X)
+
+        self.segment_list = tk.Listbox(seg_frame, height=5)
+        self.segment_list.pack(fill=tk.BOTH, expand=False)
+        self.segment_list.bind('<<ListboxSelect>>', self.on_segment_select)
+
+        edit = tk.Frame(seg_frame)
+        tk.Label(edit, text='Start:').pack(side=tk.LEFT)
+        self.start_entry = tk.Entry(edit, width=8, state='disabled')
+        self.start_entry.pack(side=tk.LEFT)
+        self.control_widgets.append(self.start_entry)
+
+        tk.Label(edit, text='End:').pack(side=tk.LEFT)
+        self.end_entry = tk.Entry(edit, width=8, state='disabled')
+        self.end_entry.pack(side=tk.LEFT)
+        self.control_widgets.append(self.end_entry)
+
+        self.update_btn = tk.Button(edit, text='Update', command=self.update_segment_times, state='disabled')
+        self.update_btn.pack(side=tk.LEFT)
+        self.control_widgets.append(self.update_btn)
+
+        edit.pack(fill=tk.X, pady=2)
+        seg_frame.pack(fill=tk.BOTH, expand=False, padx=5, pady=5)
+
+        # Status during export
+        self.export_status_var = tk.StringVar()
+        self.export_status_label = tk.Label(self, textvariable=self.export_status_var)
+        self.export_status_label.pack(fill=tk.X)
+
+        # Log output for ffmpeg
+        log_frame = tk.LabelFrame(self, text='Log')
+        self.log_text = ScrolledText(log_frame, height=12, state='disabled')
+        self.log_text.pack(fill=tk.BOTH, expand=True)
+        log_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+        self.log_queue = queue.Queue()
+        self.after(100, self.process_log_queue)
+
+        # Segment points
+        self.start_point = None
+        self.end_point = None
+
+        # timeline width cached for convenience
+        self.timeline_width = 1
+
+        # Timer
+        self.update_interval = 200
+        self.after(self.update_interval, self.update_ui)
+
+        # flag to disable interactions during export
+        self.exporting = False
+
+        # allow slider control via arrow keys
+        self.bind('<Left>', self.on_key_left)
+        self.bind('<Right>', self.on_key_right)
+        # allow scrolling to move the slider
+        self.bind('<MouseWheel>', self.on_mouse_wheel)
+        self.bind('<Button-4>', self.on_mouse_wheel)
+        self.bind('<Button-5>', self.on_mouse_wheel)
+
+    def load_video(self):
+        path = filedialog.askopenfilename(filetypes=[
+            ("Video Files", "*.mkv *.avi *.mp4")
+        ])
+        if not path:
+            return
+        if os.path.exists(path):
+            media = self.instance.media_new(path)
+            self.player.set_media(media)
+            self.player.set_hwnd(self.canvas.winfo_id())
+            self.play()
+            # Reset segment points
+            self.start_point = None
+            self.end_point = None
+            self.segment_var.set("")
+            # Clear segments
+            for seg in self.segments:
+                if seg['rect']:
+                    self.timeline.delete(seg['rect'])
+            self.segments.clear()
+            self.segment_list.delete(0, tk.END)
+            self.video_path = path
+        else:
+            messagebox.showerror("Error", f"File not found: {path}")
+
+    def play(self):
+        if self.player.get_media() is not None:
+            self.player.play()
+
+    def pause(self):
+        if self.player.is_playing():
+            self.player.pause()
+
+    def stop(self):
+        if self.player.get_media() is None:
+            return
+        self.player.stop()
+        self.scale.set(0)
+        # display first frame after stopping
+        self.player.play()
+        self.player.pause()
+
+    def on_slider_move(self, value):
+        if self.player.get_media() is None:
+            return
+        length = self.player.get_length()
+        if length > 0:
+            t = int(float(value))
+            self.player.set_time(int(t / 1000 * length))
+            if not self.player.is_playing():
+                self.player.play()
+                self.player.pause()
+
+    def update_ui(self):
+        if self.player.get_media() is not None:
+            length = self.player.get_length()
+            if length > 0:
+                pos = self.player.get_time() / length * 1000
+                self.scale.set(pos)
+                x = pos / 1000 * self.timeline_width
+                self.timeline.coords(self.playhead, x, 0, x, 40)
+        # update progress line on timeline
+        self.timeline_width = max(self.timeline.winfo_width(), 1)
+        for seg in self.segments:
+            self.update_segment_rect(seg)
+        self.after(self.update_interval, self.update_ui)
+
+    def append_log(self, text):
+        """Queue log text for display."""
+        self.log_queue.put(text)
+
+    def process_log_queue(self):
+        while not self.log_queue.empty():
+            msg = self.log_queue.get()
+            self.log_text.configure(state='normal')
+            self.log_text.insert(tk.END, msg)
+            self.log_text.see(tk.END)
+            self.log_text.configure(state='disabled')
+        self.after(100, self.process_log_queue)
+
+    def set_controls_state(self, enabled: bool):
+        state = tk.NORMAL if enabled else tk.DISABLED
+        for w in self.control_widgets:
+            w.configure(state=state)
+        self.segment_list.configure(state=state)
+        self.scale.configure(state=state)
+        self.exporting = not enabled
+
+    def set_start(self):
+        if self.exporting or self.player.get_media() is None:
+            return
+        self.start_point = self.player.get_time()
+        self.update_segment_label()
+
+    def set_end(self):
+        if self.exporting or self.player.get_media() is None:
+            return
+        self.end_point = self.player.get_time()
+        self.update_segment_label()
+
+    def update_segment_label(self):
+        if self.start_point is None:
+            msg = "Set start point"
+        else:
+            start_sec = self.start_point / 1000
+            if self.end_point is None:
+                msg = f"Start: {start_sec:.2f}s"
+            else:
+                end_sec = self.end_point / 1000
+                msg = f"Segment: {start_sec:.2f}s - {end_sec:.2f}s"
+        self.segment_var.set(msg)
+
+    # --- segment management ---
+    def add_segment(self):
+        if self.exporting:
+            return
+        if self.start_point is None or self.end_point is None:
+            return
+        if self.end_point <= self.start_point:
+            messagebox.showerror("Error", "End must be after start")
+            return
+        seg_id = len(self.segments) + 1
+        name = f"Segment {seg_id}"
+        seg = {
+            'id': seg_id,
+            'name': name,
+            'start': self.start_point,
+            'end': self.end_point,
+            'rect': None,
+        }
+        self.segments.append(seg)
+        self.segment_list.insert(tk.END, f"{seg['id']}: {seg['name']} {seg['start']/1000:.2f}s - {seg['end']/1000:.2f}s")
+        self.draw_segment(seg)
+
+    def rename_segment(self):
+        if self.exporting:
+            return
+        sel = self.segment_list.curselection()
+        if not sel:
+            return
+        index = sel[0]
+        seg = self.segments[index]
+        new_name = simpledialog.askstring("Rename", "Segment name:", initialvalue=seg['name'])
+        if new_name:
+            seg['name'] = new_name
+            self.update_segment_list()
+
+    def update_segment_list(self):
+        self.segment_list.delete(0, tk.END)
+        for seg in self.segments:
+            self.segment_list.insert(tk.END, f"{seg['id']}: {seg['name']} {seg['start']/1000:.2f}s - {seg['end']/1000:.2f}s")
+
+    def on_segment_select(self, event=None):
+        sel = self.segment_list.curselection()
+        if not sel:
+            self.start_entry.configure(state='disabled')
+            self.end_entry.configure(state='disabled')
+            self.update_btn.configure(state='disabled')
+            return
+        index = sel[0]
+        seg = self.segments[index]
+        self.start_entry.configure(state='normal')
+        self.end_entry.configure(state='normal')
+        self.update_btn.configure(state='normal')
+        self.start_entry.delete(0, tk.END)
+        self.start_entry.insert(0, f"{seg['start']/1000:.2f}")
+        self.end_entry.delete(0, tk.END)
+        self.end_entry.insert(0, f"{seg['end']/1000:.2f}")
+
+    def update_segment_times(self):
+        if self.exporting:
+            return
+        sel = self.segment_list.curselection()
+        if not sel:
+            return
+        index = sel[0]
+        seg = self.segments[index]
+        try:
+            start = float(self.start_entry.get()) * 1000
+            end = float(self.end_entry.get()) * 1000
+            if end <= start:
+                raise ValueError
+        except Exception:
+            messagebox.showerror("Error", "Invalid start/end times")
+            return
+        seg['start'] = max(0, start)
+        seg['end'] = max(seg['start'] + 1, end)
+        self.update_segment_rect(seg)
+        self.update_segment_list()
+        self.segment_list.selection_set(index)
+
+    def draw_segment(self, seg):
+        x1 = seg['start'] / max(self.player.get_length(), 1) * self.timeline_width
+        x2 = seg['end'] / max(self.player.get_length(), 1) * self.timeline_width
+        rect = self.timeline.create_rectangle(x1, 5, x2, 35, fill='skyblue', outline='blue', tags=f"seg{seg['id']}")
+        seg['rect'] = rect
+
+    def update_segment_rect(self, seg):
+        if seg['rect'] is None:
+            return
+        x1 = seg['start'] / max(self.player.get_length(), 1) * self.timeline_width
+        x2 = seg['end'] / max(self.player.get_length(), 1) * self.timeline_width
+        self.timeline.coords(seg['rect'], x1, 5, x2, 35)
+
+    # --- timeline interaction ---
+    def find_segment_at(self, x):
+        items = self.timeline.find_overlapping(x, 5, x, 35)
+        for item in items:
+            for seg in self.segments:
+                if seg['rect'] == item:
+                    return seg
+        return None
+
+    def on_timeline_click(self, event):
+        if self.exporting:
+            return
+        seg = self.find_segment_at(event.x)
+        self.active_segment = seg
+        self.drag_mode = None
+        if seg:
+            x1, _, x2, _ = self.timeline.coords(seg['rect'])
+            if abs(event.x - x1) < 5:
+                self.drag_mode = 'resize_left'
+            elif abs(event.x - x2) < 5:
+                self.drag_mode = 'resize_right'
+            else:
+                self.drag_mode = 'move'
+            self.drag_offset = event.x
+
+    def on_timeline_drag(self, event):
+        if self.exporting or not self.active_segment:
+            return
+        delta = event.x - self.drag_offset
+        length = max(self.player.get_length(), 1)
+        px_to_time = length / self.timeline_width
+        if self.drag_mode == 'move':
+            self.active_segment['start'] += delta * px_to_time
+            self.active_segment['end'] += delta * px_to_time
+        elif self.drag_mode == 'resize_left':
+            self.active_segment['start'] += delta * px_to_time
+            if self.active_segment['start'] >= self.active_segment['end']:
+                self.active_segment['start'] = self.active_segment['end'] - 1
+        elif self.drag_mode == 'resize_right':
+            self.active_segment['end'] += delta * px_to_time
+            if self.active_segment['end'] <= self.active_segment['start']:
+                self.active_segment['end'] = self.active_segment['start'] + 1
+        self.drag_offset = event.x
+        self.update_segment_rect(self.active_segment)
+        self.update_segment_list()
+
+    def on_timeline_release(self, event):
+        if self.exporting:
+            return
+        self.active_segment = None
+        self.drag_mode = None
+
+    def on_timeline_motion(self, event):
+        if self.exporting:
+            return
+        seg = self.find_segment_at(event.x)
+        cursor = ''
+        if seg:
+            x1, _, x2, _ = self.timeline.coords(seg['rect'])
+            if abs(event.x - x1) < 5 or abs(event.x - x2) < 5:
+                cursor = 'sb_h_double_arrow'
+        self.timeline.config(cursor=cursor)
+
+    def export_segments(self):
+        if not self.video_path or not self.segments:
+            messagebox.showinfo("Export", "No segments to export")
+            return
+        export_dir = filedialog.askdirectory(title="Select Export Folder")
+        if not export_dir:
+            return
+        self.set_controls_state(False)
+        self.export_status_var.set("Starting export...")
+        threading.Thread(target=self._export_worker, args=(export_dir,), daemon=True).start()
+
+    def _export_worker(self, export_dir):
+        ffmpeg_dir = os.path.join(os.path.dirname(__file__), 'ffmpeg')
+        exe = 'ffmpeg.exe' if os.name == 'nt' else 'ffmpeg'
+        ffmpeg_path = os.path.join(ffmpeg_dir, exe)
+        if not os.path.exists(ffmpeg_path):
+            self.append_log(f"ffmpeg not found at {ffmpeg_path}\n")
+            self.after(0, lambda: self.export_status_var.set("ffmpeg not found"))
+            self.after(0, lambda: self.set_controls_state(True))
+            return
+        os.makedirs(export_dir, exist_ok=True)
+        for seg in self.segments:
+            self.after(0, lambda name=seg['name']: self.export_status_var.set(f"Exporting {name}"))
+            start = seg['start'] / 1000
+            duration = (seg['end'] - seg['start']) / 1000
+            outfile = os.path.join(export_dir, f"{seg['name']}.mp3")
+            cmd = [ffmpeg_path, '-y', '-i', self.video_path,
+                   '-ss', str(start), '-t', str(duration),
+                   '-vn', '-acodec', 'mp3', outfile]
+            self.append_log("Running: " + " ".join(cmd) + "\n")
+            try:
+                proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+                for line in proc.stdout:
+                    self.append_log(line)
+                proc.wait()
+            except Exception as e:
+                self.append_log(f"Failed to export {outfile}: {e}\n")
+        self.after(0, lambda: self.export_status_var.set("Export finished"))
+        self.after(0, lambda: self.set_controls_state(True))
+
+    # --- keyboard slider control ---
+    def adjust_time(self, seconds):
+        if self.exporting or self.player.get_media() is None:
+            return
+        length = self.player.get_length()
+        if length <= 0:
+            return
+        current = self.player.get_time()
+        new_time = max(0, min(length, current + int(seconds * 1000)))
+        self.player.set_time(new_time)
+        pos = new_time / length * 1000
+        self.scale.set(pos)
+        if not self.player.is_playing():
+            self.player.play()
+            self.player.pause()
+
+    def on_key_left(self, event):
+        step = self.jump_amount.get()
+        self.adjust_time(-step)
+
+    def on_key_right(self, event):
+        step = self.jump_amount.get()
+        self.adjust_time(step)
+
+    def on_mouse_wheel(self, event):
+        if self.exporting or self.player.get_media() is None:
+            return
+        direction = 1
+        if hasattr(event, 'delta') and event.delta != 0:
+            direction = -1 if event.delta > 0 else 1
+        elif getattr(event, 'num', None) == 4:
+            direction = -1
+        elif getattr(event, 'num', None) == 5:
+            direction = 1
+        step = self.jump_amount.get()
+        self.adjust_time(direction * step)
+
+
+if __name__ == "__main__":
+    app = VideoPlayer()
+    app.mainloop()


### PR DESCRIPTION
## Summary
- group timeline slider and canvas into one section
- move playback controls and segment list into labeled frames
- place log output in its own frame and let it expand
- note the clearer layout in the README

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: No module named 'vlc')*

------
https://chatgpt.com/codex/tasks/task_e_6867ea1b6b6c832fa91c85dd70d93f4e