### PR TITLE
Add full export feature and GUI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 A simple GUI tool for marking video segments and exporting them as MP3.
 It can also export the entire audio track and shows basic metadata about
-the loaded media file.
+the loaded media file. Exported segment files include the original video
+name followed by the segment name (e.g. `video - intro.mp3`). The full
+audio export uses just the video name with an `.mp3` extension.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # mkvd
+
+A simple GUI tool for marking video segments and exporting them as MP3.
+Includes a button to export the entire audio track as a single MP3 file.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mkvd
 
 A simple GUI tool for marking video segments and exporting them as MP3.
-Includes a button to export the entire audio track as a single MP3 file.
+It can also export the entire audio track and shows basic metadata about
+the loaded media file.

--- a/main.py
+++ b/main.py
@@ -37,11 +37,11 @@ class VideoPlayer(tk.Tk):
         # Timeline slider
         self.scale = tk.Scale(self, from_=0, to=1000, orient=tk.HORIZONTAL,
                               command=self.on_slider_move)
-        self.scale.pack(fill=tk.X)
+        self.scale.pack(fill=tk.X, padx=5, pady=(5, 0))
 
         # Canvas for draggable segments
         self.timeline = tk.Canvas(self, height=40, bg='grey90')
-        self.timeline.pack(fill=tk.X)
+        self.timeline.pack(fill=tk.X, padx=5, pady=(0, 5))
         self.timeline.bind('<Button-1>', self.on_timeline_click)
         self.timeline.bind('<B1-Motion>', self.on_timeline_drag)
         self.timeline.bind('<ButtonRelease-1>', self.on_timeline_release)
@@ -112,10 +112,10 @@ class VideoPlayer(tk.Tk):
         # Segment info list
         self.segment_var = tk.StringVar()
         self.segment_label = ttk.Label(self, textvariable=self.segment_var)
-        self.segment_label.pack(fill=tk.X)
+        self.segment_label.pack(fill=tk.X, padx=5, pady=(5, 0))
 
         self.segment_list = tk.Listbox(self)
-        self.segment_list.pack(fill=tk.BOTH, expand=False)
+        self.segment_list.pack(fill=tk.BOTH, expand=False, padx=5, pady=(0, 5))
         self.segment_list.bind('<<ListboxSelect>>', self.on_segment_select)
 
         # Entry fields to edit selected segment

--- a/main.py
+++ b/main.py
@@ -396,16 +396,28 @@ class VideoPlayer(tk.Tk):
         self.segment_list.selection_set(index)
 
     def draw_segment(self, seg):
-        x1 = seg['start'] / max(self.player.get_length(), 1) * self.timeline_width
-        x2 = seg['end'] / max(self.player.get_length(), 1) * self.timeline_width
+        length = max(self.player.get_length(), 1)
+        x1 = seg['start'] / length * self.timeline_width
+        x2 = seg['end'] / length * self.timeline_width
+        margin = 1
+        if x1 <= 0:
+            x1 = margin
+        if x2 >= self.timeline_width:
+            x2 = self.timeline_width - margin
         rect = self.timeline.create_rectangle(x1, 5, x2, 35, fill='skyblue', outline='blue', tags=f"seg{seg['id']}")
         seg['rect'] = rect
 
     def update_segment_rect(self, seg):
         if seg['rect'] is None:
             return
-        x1 = seg['start'] / max(self.player.get_length(), 1) * self.timeline_width
-        x2 = seg['end'] / max(self.player.get_length(), 1) * self.timeline_width
+        length = max(self.player.get_length(), 1)
+        x1 = seg['start'] / length * self.timeline_width
+        x2 = seg['end'] / length * self.timeline_width
+        margin = 1
+        if x1 <= 0:
+            x1 = margin
+        if x2 >= self.timeline_width:
+            x2 = self.timeline_width - margin
         self.timeline.coords(seg['rect'], x1, 5, x2, 35)
 
     # --- timeline interaction ---

--- a/main.py
+++ b/main.py
@@ -513,7 +513,8 @@ class VideoPlayer(tk.Tk):
             self.after(0, lambda name=seg['name']: self.export_status_var.set(f"Exporting {name}"))
             start = seg['start'] / 1000
             duration = (seg['end'] - seg['start']) / 1000
-            outfile = os.path.join(export_dir, f"{seg['name']}.mp3")
+            base = os.path.splitext(os.path.basename(self.video_path))[0]
+            outfile = os.path.join(export_dir, f"{base} - {seg['name']}.mp3")
             cmd = [ffmpeg_path, '-y', '-i', self.video_path,
                    '-ss', str(start), '-t', str(duration),
                    '-vn', '-acodec', 'mp3', outfile]
@@ -549,7 +550,8 @@ class VideoPlayer(tk.Tk):
             self.after(0, lambda: self.set_controls_state(True))
             return
         os.makedirs(export_dir, exist_ok=True)
-        outfile = os.path.join(export_dir, 'full_audio.mp3')
+        base = os.path.splitext(os.path.basename(self.video_path))[0]
+        outfile = os.path.join(export_dir, f"{base}.mp3")
         cmd = [ffmpeg_path, '-y', '-i', self.video_path,
                '-vn', '-acodec', 'mp3', outfile]
         self.append_log("Running: " + " ".join(cmd) + "\n")

--- a/main.py
+++ b/main.py
@@ -261,13 +261,15 @@ class VideoPlayer(tk.Tk):
     def set_start(self):
         if self.exporting or self.player.get_media() is None:
             return
-        self.start_point = self.player.get_time()
+        length = self.player.get_length()
+        self.start_point = max(0, min(self.player.get_time(), length))
         self.update_segment_label()
 
     def set_end(self):
         if self.exporting or self.player.get_media() is None:
             return
-        self.end_point = self.player.get_time()
+        length = self.player.get_length()
+        self.end_point = max(0, min(self.player.get_time(), length))
         self.update_segment_label()
 
     def update_segment_label(self):
@@ -293,11 +295,14 @@ class VideoPlayer(tk.Tk):
             return
         seg_id = len(self.segments) + 1
         name = f"Segment {seg_id}"
+        length = self.player.get_length()
+        start = max(0, min(self.start_point, length))
+        end = max(start + 1, min(self.end_point, length))
         seg = {
             'id': seg_id,
             'name': name,
-            'start': self.start_point,
-            'end': self.end_point,
+            'start': start,
+            'end': end,
             'rect': None,
         }
         self.segments.append(seg)
@@ -355,8 +360,9 @@ class VideoPlayer(tk.Tk):
         except Exception:
             messagebox.showerror("Error", "Invalid start/end times")
             return
-        seg['start'] = max(0, start)
-        seg['end'] = max(seg['start'] + 1, end)
+        length = self.player.get_length()
+        seg['start'] = max(0, min(start, length))
+        seg['end'] = max(seg['start'] + 1, min(end, length))
         self.update_segment_rect(seg)
         self.update_segment_list()
         self.segment_list.selection_set(index)
@@ -416,6 +422,8 @@ class VideoPlayer(tk.Tk):
             self.active_segment['end'] += delta * px_to_time
             if self.active_segment['end'] <= self.active_segment['start']:
                 self.active_segment['end'] = self.active_segment['start'] + 1
+        self.active_segment['start'] = max(0, self.active_segment['start'])
+        self.active_segment['end'] = min(length, self.active_segment['end'])
         self.drag_offset = event.x
         self.update_segment_rect(self.active_segment)
         self.update_segment_list()


### PR DESCRIPTION
## Summary
- switch controls to `ttk` widgets for a cleaner look
- show the loaded video file in a label
- add `Export Full` button to extract entire audio track to MP3
- refresh README with brief description

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686913953cf4832f9d41ce61b33948ca